### PR TITLE
Moved the return nil of the Deploy method outside the if-else statement.

### DIFF
--- a/contract/contract.go
+++ b/contract/contract.go
@@ -57,7 +57,6 @@ func (c *Contract) Deploy(ctx context.Context, network *network.Network) error {
 		c.Address = address
 		c.Session = session
 		c.deployed = true
-		return nil
 	} else {
 		session, err := c.deployer.Bind(ctx, network, c.Address)
 		if err != nil {
@@ -65,8 +64,9 @@ func (c *Contract) Deploy(ctx context.Context, network *network.Network) error {
 		}
 
 		c.Session = session
-		return nil
 	}
+
+	return nil
 }
 
 var contracts map[string]*Contract = make(map[string]*Contract)


### PR DESCRIPTION
The Deploy method has an if-else statement, and each process executes return nil. Changed to return nil at the end of processing.